### PR TITLE
Various Features

### DIFF
--- a/CameraAnimation.cs
+++ b/CameraAnimation.cs
@@ -576,6 +576,8 @@ namespace CameraAnimation
             if (!shouldBePlaying)
                 videoCameraWasActive = originalVideoCamera.active;
 
+            if (positions.Count == 0) return;
+
             UserCameraController.field_Internal_Static_UserCameraController_0.prop_UserCameraSpace_0 = UserCameraSpace.World;
             
             anim = originalCamera.GetComponent<Animation>();

--- a/CameraAnimation.cs
+++ b/CameraAnimation.cs
@@ -302,10 +302,13 @@ namespace CameraAnimation
                 originalCamera.transform.rotation, 
                 camera.focalLength,
                 camera.lensShift,
-                camera.sensorSize);
+                camera.sensorSize, 
+                keyPosition, 
+                keyRotation, 
+                keyZoom);
         }
 
-        public void AddPosition(Vector3 position, Quaternion rotation, float focalLength, Vector2 lensShift, Vector2 sensorSize)
+        public void AddPosition(Vector3 position, Quaternion rotation, float focalLength, Vector2 lensShift, Vector2 sensorSize, bool keyPosition, bool keyRotation, bool keyZoom)
         {
             var oldValue = UserCameraController.field_Internal_Static_UserCameraController_0.prop_UserCameraSpace_0;
             UserCameraController.field_Internal_Static_UserCameraController_0.prop_UserCameraSpace_0 = UserCameraSpace.World;

--- a/CameraAnimation.cs
+++ b/CameraAnimation.cs
@@ -25,7 +25,7 @@ using CameraSliderEnum = EnumPublicSealedvaNoDoZoDo6vDoUnique;
 using CameraFocusMode = EnumPublicSealedvaOfFuSeMa5vUnique;
 using Il2CppSystem.Reflection;
 
-[assembly: MelonInfo(typeof(CameraAnimationMod), "Camera Animations", "2.3.0", "Eric van Fandenfart")]
+[assembly: MelonInfo(typeof(CameraAnimationMod), "Camera Animations", "2.3.1", "Eric van Fandenfart")]
 [assembly: MelonAdditionalDependencies("ActionMenuApi", "UIExpansionKit")]
 [assembly: MelonOptionalDependencies("TouchCamera")]
 [assembly: MelonGame]
@@ -444,11 +444,6 @@ namespace CameraAnimation
                 };
             }
 
-            ICurve CameraSettingsCurve(string key)
-            {
-                return new CurveWrapper<CameraSettings>(new AnimationCurve(), key);
-            }
-
             const string positionPrefix = nameof(Transform.localPosition);
             const string rotationPrefix = nameof(Transform.localRotation);
 
@@ -459,6 +454,12 @@ namespace CameraAnimation
             string focalDistanceKey = FocalDistanceProps[0]?.Name ?? string.Empty;
             string alternateFocalDistanceKey = FocalDistanceProps[1]?.Name ?? string.Empty;
 
+            List<(string path, string key)> pathKeysZoom = new List<(string, string)>() { ("", zoomKey), ("VideoCamera", zoomKey) };
+            List<(string path, string key)> pathKeysAperture = new List<(string, string)>() { ("", apertureKey), ("VideoCamera", apertureKey), 
+                                                                                              ("", alternateApertureKey), ("VideoCamera", alternateApertureKey) };
+            List<(string path, string key)> pathKeysFocalDistance = new List<(string, string)>() { ("", focalDistanceKey), ("VideoCamera", focalDistanceKey),
+                                                                                                   ("", alternateFocalDistanceKey), ("VideoCamera", alternateFocalDistanceKey)};
+
             return new CameraCurve()
             {
                 Transform = new TransformCurve()
@@ -466,11 +467,9 @@ namespace CameraAnimation
                     Position = Vector3Wrap(positionPrefix),
                     Rotation = Vector4Wrap(rotationPrefix)
                 },
-                Apature = CameraSettingsCurve(apertureKey),
-                ApatureAlternate = CameraSettingsCurve(alternateApertureKey),
-                FocalDistance = CameraSettingsCurve(focalDistanceKey),
-                FocalDistanceAlternate = CameraSettingsCurve(alternateFocalDistanceKey),
-                Zoom = new CurveWrapper<CameraSettings>(new AnimationCurve(), zoomKey),
+                Aperture = new CurveWrapper<CameraSettings>(new AnimationCurve(), pathKeysAperture),
+                FocalDistance = new CurveWrapper<CameraSettings>(new AnimationCurve(), pathKeysFocalDistance),
+                Zoom = new CurveWrapper<CameraSettings>(new AnimationCurve(), pathKeysZoom),
             };
         }
 
@@ -510,10 +509,8 @@ namespace CameraAnimation
 
                 if (transform.KeyFocus)
                 {
-                    curve.Apature.Add(time, transform.Aperture);
-                    curve.ApatureAlternate.Add(time, transform.Aperture);
+                    curve.Aperture.Add(time, transform.Aperture);
                     curve.FocalDistance.Add(time, transform.FocalDistance);
-                    curve.FocalDistanceAlternate.Add(time, transform.FocalDistance);
                 }
 
                 if (transform.KeyPosition)

--- a/CameraAnimation.csproj
+++ b/CameraAnimation.csproj
@@ -115,10 +115,10 @@
     <Compile Include="ICameraCurve.cs" />
     <Compile Include="ICurve.cs" />
     <Compile Include="ITransformCurve.cs" />
-    <Compile Include="IVector3Curve.cs" />
+    <Compile Include="IVectorCurves.cs" />
     <Compile Include="SerializationExtensions.cs" />
     <Compile Include="TransformCurve.cs" />
-    <Compile Include="Vector3Curve.cs" />
+    <Compile Include="VectorCurves.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SavedAnimations.cs" />
     <Compile Include="StoreTransform.cs" />

--- a/CameraAnimation.csproj
+++ b/CameraAnimation.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>C:\Program Files %28x86%29\Steam\steamapps\common\VRChat\Mods\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/CameraAnimation.csproj
+++ b/CameraAnimation.csproj
@@ -17,10 +17,11 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\Program Files %28x86%29\Steam\steamapps\common\VRChat\Mods\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -109,6 +110,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CameraAnimation.cs" />
+    <Compile Include="CameraCurve.cs" />
+    <Compile Include="CurveWrapper.cs" />
+    <Compile Include="ICameraCurve.cs" />
+    <Compile Include="ICurve.cs" />
+    <Compile Include="ITransformCurve.cs" />
+    <Compile Include="IVector3Curve.cs" />
+    <Compile Include="TransformCurve.cs" />
+    <Compile Include="Vector3Curve.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SavedAnimations.cs" />
     <Compile Include="StoreTransform.cs" />
@@ -118,4 +127,8 @@
     <EmbeddedResource Include="icons-camera" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/CameraAnimation.csproj
+++ b/CameraAnimation.csproj
@@ -111,11 +111,14 @@
   <ItemGroup>
     <Compile Include="CameraAnimation.cs" />
     <Compile Include="CameraCurve.cs" />
+    <Compile Include="CurveKey.cs" />
     <Compile Include="CurveWrapper.cs" />
     <Compile Include="ICameraCurve.cs" />
     <Compile Include="ICurve.cs" />
+    <Compile Include="ICurveKey.cs" />
     <Compile Include="ITransformCurve.cs" />
     <Compile Include="IVectorCurves.cs" />
+    <Compile Include="IVRCCamera.cs" />
     <Compile Include="QuaternionExtensions.cs" />
     <Compile Include="SerializationExtensions.cs" />
     <Compile Include="Settings.cs" />
@@ -124,6 +127,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SavedAnimations.cs" />
     <Compile Include="StoreTransform.cs" />
+    <Compile Include="VRCCamera.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="CameraAnimation.json" />

--- a/CameraAnimation.csproj
+++ b/CameraAnimation.csproj
@@ -116,6 +116,7 @@
     <Compile Include="ICurve.cs" />
     <Compile Include="ITransformCurve.cs" />
     <Compile Include="IVector3Curve.cs" />
+    <Compile Include="SerializationExtensions.cs" />
     <Compile Include="TransformCurve.cs" />
     <Compile Include="Vector3Curve.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CameraAnimation.csproj
+++ b/CameraAnimation.csproj
@@ -116,7 +116,9 @@
     <Compile Include="ICurve.cs" />
     <Compile Include="ITransformCurve.cs" />
     <Compile Include="IVectorCurves.cs" />
+    <Compile Include="QuaternionExtensions.cs" />
     <Compile Include="SerializationExtensions.cs" />
+    <Compile Include="Settings.cs" />
     <Compile Include="TransformCurve.cs" />
     <Compile Include="VectorCurves.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CameraAnimation.csproj.user
+++ b/CameraAnimation.csproj.user
@@ -8,4 +8,10 @@
   <PropertyGroup>
     <ReferencePath>C:\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\;C:\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\;C:\Program Files (x86)\Steam\steamapps\common\VRChat\Mods\</ReferencePath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files %28x86%29\Steam\steamapps\common\VRChat\VRChat.exe</StartProgram>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
+    <StartArguments>--no-vr</StartArguments>
+  </PropertyGroup>
 </Project>

--- a/CameraAnimation.csproj.user
+++ b/CameraAnimation.csproj.user
@@ -5,4 +5,7 @@
     <StartProgram>C:\Program Files %28x86%29\Steam\steamapps\common\VRChat\VRChat.exe</StartProgram>
     <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
+  <PropertyGroup>
+    <ReferencePath>C:\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\;C:\Program Files (x86)\Steam\steamapps\common\VRChat\MelonLoader\Managed\;C:\Program Files (x86)\Steam\steamapps\common\VRChat\Mods\</ReferencePath>
+  </PropertyGroup>
 </Project>

--- a/CameraAnimation.csproj.user
+++ b/CameraAnimation.csproj.user
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files %28x86%29\Steam\steamapps\common\VRChat\VRChat.exe</StartProgram>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
+  </PropertyGroup>
+</Project>

--- a/CameraAnimation.sln
+++ b/CameraAnimation.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31424.327
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32526.322
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CameraAnimation", "CameraAnimation.csproj", "{4AD9CAFD-65DE-41EA-A8C9-22F3B41CE2D3}"
 EndProject

--- a/CameraCurve.cs
+++ b/CameraCurve.cs
@@ -15,9 +15,9 @@ namespace CameraAnimation
         public IVector2Curve SensorSize { get; set; }
         public ITransformCurve Transform { get; set; }
         public ICurve Apature { get; set; }
-        public ICurve ApatureCopy { get; set; } //there are 2 values for it that need to be animated
+        public ICurve ApatureAlternate { get; set; } //there are 2 values for it that need to be animated
         public ICurve FocalDistance { get; set; }
-        public ICurve FocalDistanceCopy { get; set; }
+        public ICurve FocalDistanceAlternate { get; set; }
 
         public int Length => Math.Max(FocalLength.Length, Transform.Length);
 

--- a/CameraCurve.cs
+++ b/CameraCurve.cs
@@ -14,6 +14,10 @@ namespace CameraAnimation
         public IVector2Curve LensShift { get; set; }
         public IVector2Curve SensorSize { get; set; }
         public ITransformCurve Transform { get; set; }
+        public ICurve Apature { get; set; }
+        public ICurve ApatureCopy { get; set; } //there are 2 values for it that need to be animated
+        public ICurve FocalDistance { get; set; }
+        public ICurve FocalDistanceCopy { get; set; }
 
         public int Length => Math.Max(FocalLength.Length, Transform.Length);
 
@@ -23,6 +27,8 @@ namespace CameraAnimation
             FocalLength.Set(clip);
             LensShift.Set(clip);
             SensorSize.Set(clip);
+            Apature.Set(clip);
+            FocalDistance.Set(clip);
         }
     }
 }

--- a/CameraCurve.cs
+++ b/CameraCurve.cs
@@ -10,23 +10,19 @@ namespace CameraAnimation
     public class CameraCurve : ICameraCurve
     {
 
-        public ICurve FocalLength { get; set; }
-        public IVector2Curve LensShift { get; set; }
-        public IVector2Curve SensorSize { get; set; }
+        public ICurve Zoom { get; set; }
         public ITransformCurve Transform { get; set; }
         public ICurve Apature { get; set; }
         public ICurve ApatureAlternate { get; set; } //there are 2 values for it that need to be animated
         public ICurve FocalDistance { get; set; }
         public ICurve FocalDistanceAlternate { get; set; }
 
-        public int Length => Math.Max(FocalLength.Length, Transform.Length);
+        public int Length => Math.Max(Zoom.Length, Transform.Length);
 
         public void Set(AnimationClip clip)
         {
             Transform.Set(clip);
-            FocalLength.Set(clip);
-            LensShift.Set(clip);
-            SensorSize.Set(clip);
+            Zoom.Set(clip);
             Apature.Set(clip);
             FocalDistance.Set(clip);
         }

--- a/CameraCurve.cs
+++ b/CameraCurve.cs
@@ -12,10 +12,8 @@ namespace CameraAnimation
 
         public ICurve Zoom { get; set; }
         public ITransformCurve Transform { get; set; }
-        public ICurve Apature { get; set; }
-        public ICurve ApatureAlternate { get; set; } //there are 2 values for it that need to be animated
+        public ICurve Aperture { get; set; }
         public ICurve FocalDistance { get; set; }
-        public ICurve FocalDistanceAlternate { get; set; }
 
         public int Length => Math.Max(Zoom.Length, Transform.Length);
 
@@ -23,7 +21,7 @@ namespace CameraAnimation
         {
             Transform.Set(clip);
             Zoom.Set(clip);
-            Apature.Set(clip);
+            Aperture.Set(clip);
             FocalDistance.Set(clip);
         }
     }

--- a/CameraCurve.cs
+++ b/CameraCurve.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace CameraAnimation
+{
+    public class CameraCurve : ICameraCurve
+    {
+
+        public ICurve FocalLength { get; set; }
+        public IVector2Curve LensShift { get; set; }
+        public IVector2Curve SensorSize { get; set; }
+        public ITransformCurve Transform { get; set; }
+
+        public int Length => Math.Max(FocalLength.Length, Transform.Length);
+
+        public void Set(AnimationClip clip)
+        {
+            Transform.Set(clip);
+            FocalLength.Set(clip);
+            LensShift.Set(clip);
+            SensorSize.Set(clip);
+        }
+    }
+}

--- a/CurveKey.cs
+++ b/CurveKey.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CameraAnimation
+{
+    /// <summary>
+    /// Represents an enumerable key value pair that when iterated returns several versions of the same key
+    /// </summary>
+    public struct CurveKey : ICurveKey, IEnumerable<ICurveKey>
+    {
+        public string Path { get; set; }
+        public string Key { get; set; }
+        public string AlternateKey { get; set; }
+
+        public CurveKey(string path, string key, string alternateKey = null)
+        {
+            Path = path;
+            Key = key;
+            AlternateKey = alternateKey;
+        }
+
+        public IEnumerator<ICurveKey> GetEnumerator()
+        {
+            yield return new CurveKey(string.Empty, Key);
+            yield return this;
+            if (AlternateKey != null)
+            {
+                yield return new CurveKey(Path, AlternateKey);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return (IEnumerator)GetEnumerator();
+        }
+    }
+}

--- a/CurveWrapper.cs
+++ b/CurveWrapper.cs
@@ -10,12 +10,20 @@ namespace CameraAnimation
     public class CurveWrapper<T> : ICurve
     {
         private readonly AnimationCurve curve;
-        private readonly string key;
+
+        private readonly List<(string path, string key)> pathKeys = new List<(string, string)>();
         private readonly Il2CppSystem.Type type;
 
         public CurveWrapper(AnimationCurve curve, string key)
         {
-            this.key = key;
+            pathKeys.Add((string.Empty, key));
+            this.curve = curve;
+            this.type = UnhollowerRuntimeLib.Il2CppType.Of<T>();
+        }
+
+        public CurveWrapper(AnimationCurve curve, List<(string path, string key)> keys)
+        {
+            pathKeys = keys;
             this.curve = curve;
             this.type = UnhollowerRuntimeLib.Il2CppType.Of<T>();
         }
@@ -33,7 +41,10 @@ namespace CameraAnimation
 
         public void Set(AnimationClip clip)
         {
-            clip.SetCurve(string.Empty, type, key, curve);
+            foreach (var (path, key) in pathKeys)
+            {
+                clip.SetCurve(path, type, key, curve);
+            }
         }
     }
 }

--- a/CurveWrapper.cs
+++ b/CurveWrapper.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace CameraAnimation
+{
+    public class CurveWrapper<T> : ICurve
+    {
+        private readonly AnimationCurve curve;
+        private readonly string key;
+        private readonly Il2CppSystem.Type type;
+
+        public CurveWrapper(AnimationCurve curve, string key)
+        {
+            this.key = key;
+            this.curve = curve;
+            this.type = UnhollowerRuntimeLib.Il2CppType.Of<T>();
+        }
+
+        public Keyframe this[int index] => curve.keys[index];
+
+        public int Length => curve.length;
+
+        public Keyframe First => curve.length > 0 ? curve.keys[0] : default;
+        public Keyframe Last => curve.length > 0 ? curve.keys[curve.length-1] : default;
+
+        public int Add(float time, float value) => curve.AddKey(time, value);
+
+        public float Evaluate(float time) => curve.Evaluate(time);
+
+        public void Set(AnimationClip clip)
+        {
+            clip.SetCurve(string.Empty, type, key, curve);
+        }
+    }
+}

--- a/CurveWrapper.cs
+++ b/CurveWrapper.cs
@@ -11,17 +11,18 @@ namespace CameraAnimation
     {
         private readonly AnimationCurve curve;
 
-        private readonly List<(string path, string key)> pathKeys = new List<(string, string)>();
+        private readonly IEnumerable<ICurveKey> pathKeys;
         private readonly Il2CppSystem.Type type;
 
         public CurveWrapper(AnimationCurve curve, string key)
         {
-            pathKeys.Add((string.Empty, key));
+            // technically we shouldn't instantiate this here, but im lazy
+            pathKeys = new CurveKey("",key);
             this.curve = curve;
             this.type = UnhollowerRuntimeLib.Il2CppType.Of<T>();
         }
 
-        public CurveWrapper(AnimationCurve curve, List<(string path, string key)> keys)
+        public CurveWrapper(AnimationCurve curve, IEnumerable<ICurveKey> keys)
         {
             pathKeys = keys;
             this.curve = curve;
@@ -41,9 +42,9 @@ namespace CameraAnimation
 
         public void Set(AnimationClip clip)
         {
-            foreach (var (path, key) in pathKeys)
+            foreach (var key in pathKeys)
             {
-                clip.SetCurve(path, type, key, curve);
+                clip.SetCurve(key.Path, type, key.Key, curve);
             }
         }
     }

--- a/ICameraCurve.cs
+++ b/ICameraCurve.cs
@@ -3,9 +3,7 @@
     public interface ICameraCurve : IClip
     {
         ITransformCurve Transform { get; set; }
-        ICurve FocalLength { get; set; }
-        IVector2Curve LensShift { get; set; }
-        IVector2Curve SensorSize { get; set; }
+        ICurve Zoom { get; set; }
         ICurve Apature { get; set; }
         ICurve ApatureAlternate { get; set; } //there are 2 values for it that need to be animated
         ICurve FocalDistance { get; set; }

--- a/ICameraCurve.cs
+++ b/ICameraCurve.cs
@@ -7,8 +7,8 @@
         IVector2Curve LensShift { get; set; }
         IVector2Curve SensorSize { get; set; }
         ICurve Apature { get; set; }
-        ICurve ApatureCopy { get; set; } //there are 2 values for it that need to be animated
+        ICurve ApatureAlternate { get; set; } //there are 2 values for it that need to be animated
         ICurve FocalDistance { get; set; }
-        ICurve FocalDistanceCopy { get; set; }//there are 2 values for it that need to be animated
+        ICurve FocalDistanceAlternate { get; set; }//there are 2 values for it that need to be animated
     }
 }

--- a/ICameraCurve.cs
+++ b/ICameraCurve.cs
@@ -1,0 +1,10 @@
+﻿namespace CameraAnimation
+{
+    public interface ICameraCurve : IClip
+    {
+        ITransformCurve Transform { get; set; }
+        ICurve FocalLength { get; set; }
+        IVector2Curve LensShift { get; set; }
+        IVector2Curve SensorSize { get; set; }
+    }
+}

--- a/ICameraCurve.cs
+++ b/ICameraCurve.cs
@@ -6,5 +6,9 @@
         ICurve FocalLength { get; set; }
         IVector2Curve LensShift { get; set; }
         IVector2Curve SensorSize { get; set; }
+        ICurve Apature { get; set; }
+        ICurve ApatureCopy { get; set; } //there are 2 values for it that need to be animated
+        ICurve FocalDistance { get; set; }
+        ICurve FocalDistanceCopy { get; set; }//there are 2 values for it that need to be animated
     }
 }

--- a/ICameraCurve.cs
+++ b/ICameraCurve.cs
@@ -4,9 +4,7 @@
     {
         ITransformCurve Transform { get; set; }
         ICurve Zoom { get; set; }
-        ICurve Apature { get; set; }
-        ICurve ApatureAlternate { get; set; } //there are 2 values for it that need to be animated
+        ICurve Aperture { get; set; }
         ICurve FocalDistance { get; set; }
-        ICurve FocalDistanceAlternate { get; set; }//there are 2 values for it that need to be animated
     }
 }

--- a/ICurve.cs
+++ b/ICurve.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+
+namespace CameraAnimation
+{
+    public interface ICurve : IClip
+    {
+        Keyframe this[int index] { get; }
+        Keyframe First { get; }
+        Keyframe Last { get; }
+
+        int Add(float time, float value);
+        float Evaluate(float time);
+    }
+
+    public interface IClip
+    {
+        int Length { get; }
+        void Set(AnimationClip clip);
+    }
+}

--- a/ICurveKey.cs
+++ b/ICurveKey.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace CameraAnimation
+{
+    public interface ICurveKey
+    {
+        string Key { get; set; }
+        string Path { get; set; }
+    }
+}

--- a/ITransformCurve.cs
+++ b/ITransformCurve.cs
@@ -3,6 +3,7 @@
     public interface ITransformCurve : IClip
     {
         IVector3Curve Position { get; set; }
-        IVector3Curve Rotation { get; set; }
+        IVector4Curve Rotation { get; set; }
+        
     }
 }

--- a/ITransformCurve.cs
+++ b/ITransformCurve.cs
@@ -1,0 +1,8 @@
+﻿namespace CameraAnimation
+{
+    public interface ITransformCurve : IClip
+    {
+        IVector3Curve Position { get; set; }
+        IVector3Curve Rotation { get; set; }
+    }
+}

--- a/IVRCCamera.cs
+++ b/IVRCCamera.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+
+using CameraSettings = MonoBehaviourPublicAcInCaInTeShInMaBoInUnique;
+
+namespace CameraAnimation
+{
+    public interface IVRCCamera
+    {
+        GameObject PhotoCamera { get; }
+        CameraSettings Settings { get; }
+        GameObject VideoCamera { get; }
+    }
+}

--- a/IVector3Curve.cs
+++ b/IVector3Curve.cs
@@ -1,0 +1,25 @@
+﻿using UnityEngine;
+
+namespace CameraAnimation
+{
+    public interface IVector3Curve : IVector2Curve
+    {
+        ICurve Z { get; set; }
+
+        (int, int, int) Add(float time, float x, float y, float z);
+        (int, int, int) Add(float time, Vector3 value);
+
+        new Vector3 Evaluate(float time);
+    }
+
+    public interface IVector2Curve : IClip
+    {
+        ICurve X { get; set; }
+        ICurve Y { get; set; }
+
+        (int, int) Add(float time, float x, float y);
+        (int, int) Add(float time, Vector2 value);
+
+        Vector2 Evaluate(float time);
+    }
+}

--- a/IVectorCurves.cs
+++ b/IVectorCurves.cs
@@ -2,6 +2,17 @@
 
 namespace CameraAnimation
 {
+
+    public interface IVector4Curve : IVector3Curve
+    {
+        ICurve W { get; set; }
+
+        (int, int, int, int) Add(float time, float x, float y, float z, float w);
+        (int, int, int, int) Add(float time, Vector4 value);
+
+        new Vector4 Evaluate(float time);
+    }
+
     public interface IVector3Curve : IVector2Curve
     {
         ICurve Z { get; set; }

--- a/QuaternionExtensions.cs
+++ b/QuaternionExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace CameraAnimation
+{
+    public static class QuaternionExtensions
+    {
+        // Creates new vector4 with the real and imaginary parts of the provided quaternion
+        // Why is this not implemented as a explicit/implicit cast overload unity.....
+        public static Vector4 ToVector4(this Quaternion value)
+        { 
+            return new Vector4(value.x, value.y, value.z, value.w);
+        }
+
+        // Creates new Quaternion using the values within the provided vector4 as the real and imaginary parts of the quaternion
+        // Why is this not implemented as a explicit/implicit cast overload unity.....
+        public static Quaternion ToQuaternion(this Vector4 value)
+        { 
+            return new Quaternion(value.x, value.y, value.z, value.w);
+        }
+    }
+}

--- a/SavedAnimations.cs
+++ b/SavedAnimations.cs
@@ -21,6 +21,7 @@ namespace CameraAnimation
         private const string boolRegex = "\\D{4,5};";
         private const string vector2Regex = floatRegex + floatRegex;
         private const string vector3Regex = vector2Regex + floatRegex;
+        private const string vector4Regex = vector3Regex + floatRegex;
         private CameraAnimationMod cameraAnimationMod;
         private MethodInfo UseKeyboardOnlyForText;
         public SavedAnimations(CameraAnimationMod cameraAnimationMod)
@@ -90,7 +91,7 @@ namespace CameraAnimation
         {
             cameraAnimationMod.ClearAnimation();
             
-            Regex lineRegex = new Regex(vector3Regex + vector3Regex + floatRegex + vector2Regex + vector2Regex + boolRegex + boolRegex + boolRegex);
+            Regex lineRegex = new Regex(vector3Regex + vector4Regex + floatRegex + vector2Regex + vector2Regex + boolRegex + boolRegex + boolRegex);
             foreach (var line in text.Split('\n'))
             {
                 if (string.IsNullOrWhiteSpace(line)) continue;
@@ -102,23 +103,23 @@ namespace CameraAnimation
                     return;
                 }
                 Vector3 positions = ParseVector3(match, 1);
-
-                Quaternion rotation  = Quaternion.Euler(ParseVector3(match, 4));
+                Vector4 vectorRot = ParseVector4(match, 4);
+                Quaternion rotation  = new Quaternion(vectorRot.x, vectorRot.y, vectorRot.z, vectorRot.w);
 
                 float focalLength = DefaultFieldOfView;
 
-                if (float.TryParse(match.Groups[7].Value, out float parsed))
+                if (float.TryParse(match.Groups[8].Value, out float parsed))
                 {
                     focalLength = parsed;
                 }
 
-                Vector2 lensShift = ParseVector2(match, 7);
+                Vector2 lensShift = ParseVector2(match, 8);
 
-                Vector2 sensorSize = ParseVector2(match, 9);
+                Vector2 sensorSize = ParseVector2(match, 10);
 
-                bool keyPosition = ParseBool(match, 10);
-                bool keyRotation = ParseBool(match, 11);
-                bool keyZoom = ParseBool(match, 12);
+                bool keyPosition = ParseBool(match, 11);
+                bool keyRotation = ParseBool(match, 12);
+                bool keyZoom = ParseBool(match, 13);
 
                 cameraAnimationMod.AddPosition(positions, rotation, focalLength, lensShift, sensorSize, keyPosition, keyRotation, keyZoom);
             }
@@ -131,6 +132,30 @@ namespace CameraAnimation
                 return x;
             }
             return false;
+        }
+
+        Vector4 ParseVector4(Match match, int offset)
+        {
+            Vector4 result = new Vector4();
+
+            if (float.TryParse(match.Groups[offset].Value, out float x))
+            {
+                result.x = x;
+            }
+            if (float.TryParse(match.Groups[offset + 1].Value, out float y))
+            {
+                result.y = y;
+            }
+            if (float.TryParse(match.Groups[offset + 2].Value, out float z))
+            {
+                result.z = z;
+            }
+            if (float.TryParse(match.Groups[offset + 3].Value, out float w))
+            {
+                result.w = w;
+            }
+
+            return result;
         }
 
         Vector3 ParseVector3(Match match, int offset)

--- a/SavedAnimations.cs
+++ b/SavedAnimations.cs
@@ -17,6 +17,8 @@ namespace CameraAnimation
     public class SavedAnimations
     {
         public const float DefaultFieldOfView = 50.0f;
+        public const float DefaultApeture = 15.0f;
+        public const float DefaultFocalDistance = 1.5f;
         private const string floatRegex = "([0-9-.]+);";
         private const string boolRegex = "\\D{4,5};";
         private const string vector2Regex = floatRegex + floatRegex;
@@ -108,20 +110,35 @@ namespace CameraAnimation
 
                 float focalLength = DefaultFieldOfView;
 
-                if (float.TryParse(match.Groups[8].Value, out float parsed))
+                if (float.TryParse(match.Groups[8].Value, out float parsedFocalLength))
                 {
-                    focalLength = parsed;
+                    focalLength = parsedFocalLength;
                 }
 
                 Vector2 lensShift = ParseVector2(match, 8);
 
                 Vector2 sensorSize = ParseVector2(match, 10);
 
-                bool keyPosition = ParseBool(match, 11);
-                bool keyRotation = ParseBool(match, 12);
-                bool keyZoom = ParseBool(match, 13);
 
-                cameraAnimationMod.AddPosition(positions, rotation, focalLength, lensShift, sensorSize, keyPosition, keyRotation, keyZoom);
+                float apeture = DefaultApeture;
+                float focalDistance = DefaultFocalDistance;
+
+                if (float.TryParse(match.Groups[11].Value, out float parsedApeture))
+                {
+                    apeture = parsedApeture;
+                }
+
+                if (float.TryParse(match.Groups[12].Value, out float parsedFocalDistance))
+                {
+                    focalDistance = parsedFocalDistance;
+                }
+
+                bool keyPosition = ParseBool(match, 13);
+                bool keyRotation = ParseBool(match, 14);
+                bool keyZoom = ParseBool(match, 15);
+                bool keyFocus = ParseBool(match, 16);
+
+                cameraAnimationMod.AddPosition(positions, rotation, focalLength, lensShift, sensorSize, keyPosition, keyRotation, keyZoom, keyFocus);
             }
         }
 

--- a/SavedAnimations.cs
+++ b/SavedAnimations.cs
@@ -16,9 +16,6 @@ namespace CameraAnimation
 {
     public class SavedAnimations
     {
-        public const float DefaultFieldOfView = 50.0f;
-        public const float DefaultApeture = 15.0f;
-        public const float DefaultFocalDistance = 1.5f;
         private const string floatRegex = "([0-9-.]+);";
         private const string boolRegex = "\\D{4,5};";
         private const string vector2Regex = floatRegex + floatRegex;
@@ -108,7 +105,7 @@ namespace CameraAnimation
                 Vector4 vectorRot = ParseVector4(match, 4);
                 Quaternion rotation  = new Quaternion(vectorRot.x, vectorRot.y, vectorRot.z, vectorRot.w);
 
-                float focalLength = DefaultFieldOfView;
+                float focalLength = Settings.Camera.DefaultFieldOfView;
 
                 if (float.TryParse(match.Groups[8].Value, out float parsedFocalLength))
                 {
@@ -120,12 +117,12 @@ namespace CameraAnimation
                 Vector2 sensorSize = ParseVector2(match, 10);
 
 
-                float apeture = DefaultApeture;
-                float focalDistance = DefaultFocalDistance;
+                float aperature = Settings.Camera.DefaultAperture;
+                float focalDistance = Settings.Camera.DefaultFocalDistance;
 
                 if (float.TryParse(match.Groups[11].Value, out float parsedApeture))
                 {
-                    apeture = parsedApeture;
+                    aperature = parsedApeture;
                 }
 
                 if (float.TryParse(match.Groups[12].Value, out float parsedFocalDistance))
@@ -138,7 +135,14 @@ namespace CameraAnimation
                 bool keyZoom = ParseBool(match, 15);
                 bool keyFocus = ParseBool(match, 16);
 
-                cameraAnimationMod.AddPosition(positions, rotation, focalLength, lensShift, sensorSize, keyPosition, keyRotation, keyZoom, keyFocus);
+                var newTransform = new StoreTransform(aperature, focalDistance, focalLength, lensShift, sensorSize, positions, rotation) { 
+                    KeyPosition = keyPosition,
+                    KeyRotation = keyRotation,
+                    KeyZoom = keyZoom,
+                    KeyFocus = keyFocus
+                };
+
+                cameraAnimationMod.AddPosition(newTransform);
             }
         }
 

--- a/SerializationExtensions.cs
+++ b/SerializationExtensions.cs
@@ -10,6 +10,14 @@ namespace CameraAnimation
 {
     public static class SerializationExtensions
     {
+        public static void Serialize(this Vector4 vector, StringBuilder builder)
+        {
+            vector.x.Serialize(builder);
+            vector.y.Serialize(builder);
+            vector.z.Serialize(builder);
+            vector.w.Serialize(builder, ';');
+        }
+
         public static void Serialize(this Vector3 vector, StringBuilder builder)
         {
             vector.x.Serialize(builder);

--- a/SerializationExtensions.cs
+++ b/SerializationExtensions.cs
@@ -12,28 +12,28 @@ namespace CameraAnimation
     {
         public static void Serialize(this Vector4 vector, StringBuilder builder)
         {
-            vector.x.Serialize(builder);
-            vector.y.Serialize(builder);
-            vector.z.Serialize(builder);
+            vector.x.Serialize(builder, ';');
+            vector.y.Serialize(builder, ';');
+            vector.z.Serialize(builder, ';');
             vector.w.Serialize(builder, ';');
         }
 
         public static void Serialize(this Vector3 vector, StringBuilder builder)
         {
-            vector.x.Serialize(builder);
-            vector.y.Serialize(builder);
+            vector.x.Serialize(builder, ';');
+            vector.y.Serialize(builder, ';');
             vector.z.Serialize(builder, ';');
         }
 
         public static void Serialize(this Vector2 vector, StringBuilder builder)
         {
-            vector.x.Serialize(builder);
+            vector.x.Serialize(builder, ';');
             vector.y.Serialize(builder, ';');
         }
 
         public static void Serialize(this float value, StringBuilder builder, char? postFix = null)
         {
-            builder.Append(value.ToString(CultureInfo.InvariantCulture));
+            builder.Append(Math.Round(value, 5).ToString(CultureInfo.InvariantCulture));
             if (postFix != null)
             {
                 builder.Append(postFix);

--- a/SerializationExtensions.cs
+++ b/SerializationExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace CameraAnimation
+{
+    public static class SerializationExtensions
+    {
+        public static void Serialize(this Vector3 vector, StringBuilder builder)
+        {
+            vector.x.Serialize(builder);
+            vector.y.Serialize(builder);
+            vector.z.Serialize(builder, ';');
+        }
+
+        public static void Serialize(this Vector2 vector, StringBuilder builder)
+        {
+            vector.x.Serialize(builder);
+            vector.y.Serialize(builder, ';');
+        }
+
+        public static void Serialize(this float value, StringBuilder builder, char? postFix = null)
+        {
+            builder.Append(value.ToString(CultureInfo.InvariantCulture));
+            if (postFix != null)
+            {
+                builder.Append(postFix);
+            }
+        }
+
+        public static void Serialize(this bool value, StringBuilder builder)
+        {
+            builder.Append(value.ToString(CultureInfo.InvariantCulture));
+            builder.Append(';');
+        }
+    }
+}

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace CameraAnimation
+{
+    public static class Settings
+    {
+        public static class Camera {
+            public static float DefaultFieldOfView { get; set; } = 50.0f;
+            public static float DefaultAperture { get; set; } = 15.0f;
+            public static float DefaultFocalDistance { get; set; } = 1.5f;
+            public static float DefaultFocalLength { get; set; }
+            public static Vector2 DefaultSensorSize { get;set; }
+            public static Vector2 DefaultLensShift { get; set; }
+        }
+
+        public static class Keying
+        {
+            public static bool KeyPosition { get; set; } = true;
+            public static bool KeyRotation { get; set; } = true;
+            public static bool KeyZoom { get; set; } = true;
+            public static bool KeyFocus { get; set; } = true;
+            public static float DefaultMaxTimeBetweenKeyFrames { get; set; } = 5f;
+            public static float MaxTimeBetweenKeyFrames { get; set; } = 5f;
+            public static float DefaultMinTimeBetweenKeyFrames { get; set; } = 0.2f;
+            public static float MinTimeBetweenKeyFrames { get; set; } = 0.2f;
+        }
+
+        public static class UI
+        {
+            public static bool ShowPath { get; set; } = true;
+            public static float PathWidth { get; set; } = 0.025f;
+        }
+
+        public static class Interaction
+        {
+            public static bool AllowCameraPickup { get; set; } = false;
+        }
+
+        public static class Animation
+        {
+            public static float Speed { get; set; } = 0.5f;
+        }
+    }
+}

--- a/Settings.cs
+++ b/Settings.cs
@@ -10,10 +10,9 @@ namespace CameraAnimation
     public static class Settings
     {
         public static class Camera {
-            public static float DefaultFieldOfView { get; set; } = 50.0f;
+            public static float DefaultZoom { get; set; } = 50.0f;
             public static float DefaultAperture { get; set; } = 15.0f;
             public static float DefaultFocalDistance { get; set; } = 1.5f;
-            public static float DefaultFocalLength { get; set; }
             public static Vector2 DefaultSensorSize { get; set; } = new Vector2(70, 51);
             public static Vector2 DefaultLensShift { get; set; } = new Vector2(0, 0);
         }

--- a/Settings.cs
+++ b/Settings.cs
@@ -14,8 +14,8 @@ namespace CameraAnimation
             public static float DefaultAperture { get; set; } = 15.0f;
             public static float DefaultFocalDistance { get; set; } = 1.5f;
             public static float DefaultFocalLength { get; set; }
-            public static Vector2 DefaultSensorSize { get;set; }
-            public static Vector2 DefaultLensShift { get; set; }
+            public static Vector2 DefaultSensorSize { get; set; } = new Vector2(70, 51);
+            public static Vector2 DefaultLensShift { get; set; } = new Vector2(0, 0);
         }
 
         public static class Keying

--- a/Settings.cs
+++ b/Settings.cs
@@ -27,22 +27,66 @@ namespace CameraAnimation
             public static float MaxTimeBetweenKeyFrames { get; set; } = 5f;
             public static float DefaultMinTimeBetweenKeyFrames { get; set; } = 0.2f;
             public static float MinTimeBetweenKeyFrames { get; set; } = 0.2f;
+
+            public static void Reset()
+            {
+                KeyPosition = true;
+                KeyRotation = true;
+                KeyZoom = true;
+                KeyFocus = true;
+                MaxTimeBetweenKeyFrames = DefaultMaxTimeBetweenKeyFrames;
+                MinTimeBetweenKeyFrames = DefaultMinTimeBetweenKeyFrames;
+            }
         }
 
         public static class UI
         {
             public static bool ShowPath { get; set; } = true;
-            public static float PathWidth { get; set; } = 0.025f;
+            public static float DefaultPathWidth { get; set; } = 0.25f;
+            public static float PathWidth { get => _pathWidth * pathWidthModifier; set { _pathWidth = value; } }
+            private static float _pathWidth = 0.25f;
+            private static readonly float pathWidthModifier = 0.1f;
+
+            public static bool SyncLens { get; set; } = true;
+
+            public static void Reset()
+            {
+                ShowPath = true;
+                PathWidth = DefaultPathWidth;
+                SyncLens = true;
+            }
         }
 
         public static class Interaction
         {
             public static bool AllowCameraPickup { get; set; } = false;
+            public static void Reset()
+            {
+                AllowCameraPickup = false;
+            }
         }
 
         public static class Animation
         {
+            public static float DefaultSpeed { get; set; } = 0.5f;
             public static float Speed { get; set; } = 0.5f;
+            public static bool LoopMode { get; set; } = false;
+            public static bool ConstantSpeed { get; set; } = false;
+
+            public static void Reset()
+            {
+                Speed = DefaultSpeed;
+                LoopMode = false;
+                ConstantSpeed = false;
+            }
+        }
+
+        public static void Reset()
+        {
+            Keying.Reset();
+            UI.Reset();
+            Interaction.Reset();
+            Animation.Reset();
         }
     }
 }

--- a/StoreTransform.cs
+++ b/StoreTransform.cs
@@ -17,6 +17,9 @@ namespace CameraAnimation
 
         public Vector2 SensorSize => _cachedCamera.sensorSize;
 
+        public bool KeyPosition { get; set; } = true;
+        public bool KeyRotation { get; set; } = true;
+        public bool KeyZoom { get; set; } = true;
 
         private readonly Camera _cachedCamera;
 

--- a/StoreTransform.cs
+++ b/StoreTransform.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Text;
 using UnityEngine;
 
 namespace CameraAnimation
@@ -41,6 +43,18 @@ namespace CameraAnimation
             Photocamera = camera;
             _cachedCamera = Photocamera.GetComponent<Camera>();
             this.setCameraPickupable = setCameraPickupable;
+        }
+
+        public void Serialize(StringBuilder builder)
+        {
+            Position.Serialize(builder);
+            EulerAngles.Serialize(builder);
+            FocalLength.Serialize(builder, ';');
+            LensShift.Serialize(builder);
+            SensorSize.Serialize(builder);
+            KeyPosition.Serialize(builder);
+            KeyRotation.Serialize(builder);
+            KeyZoom.Serialize(builder);
         }
     }
 }

--- a/StoreTransform.cs
+++ b/StoreTransform.cs
@@ -1,17 +1,29 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace CameraAnimation
 {
     public class StoreTransform
     {
         public GameObject Photocamera;
+
         public Vector3 Position => Photocamera.transform.position;
+
         public Vector3 EulerAngles => Photocamera.transform.eulerAngles;
         public Vector3 EulerAnglesCorrected;
+
+        public float FocalLength => _cachedCamera.focalLength;
+        public Vector2 LensShift => _cachedCamera.lensShift;
+
+        public Vector2 SensorSize => _cachedCamera.sensorSize;
+
+
+        private readonly Camera _cachedCamera;
 
         public StoreTransform(GameObject camera)
         {
             Photocamera = camera;
+            _cachedCamera = Photocamera.GetComponent<Camera>();
         }
     }
 }

--- a/StoreTransform.cs
+++ b/StoreTransform.cs
@@ -9,20 +9,19 @@ namespace CameraAnimation
     public class StoreTransform
     {
         public GameObject Photocamera { get => _photoCamera; set => SetGameObject(value); }
-        
-        public Vector3 Position => Photocamera?.transform.position ?? _cachedPosition;
-        public Vector4 Rotation => Photocamera?.transform.localRotation.ToVector4() ?? _cachedRotation.ToVector4();
+
+        public Vector3 Position => GetPosition();
+        public Vector4 Rotation => GetRotation();
         public float Aperture => GetAperture();
         public float FocalDistance => GetFocalDistance();
-
-        public float FocalLength => _cachedCamera?.focalLength ?? _cachedFocalLength;
-        public Vector2 LensShift => _cachedCamera?.lensShift ?? _cachedLensShift;
-        public Vector2 SensorSize => _cachedCamera?.sensorSize ?? _cachedSensorSize;
+        public float Zoom => GetZoom();
 
         public bool KeyPosition { get; set; } = Settings.Keying.KeyPosition;
         public bool KeyRotation { get; set; } = Settings.Keying.KeyRotation;
         public bool KeyZoom { get; set; } = Settings.Keying.KeyZoom;
         public bool KeyFocus { get; set; } = Settings.Keying.KeyFocus;
+
+
 
         public bool Pickupable
         {
@@ -34,32 +33,28 @@ namespace CameraAnimation
             }
         }
 
-        public static Action<bool, GameObject> SetCameraPickupable { get; set; } = (x,y)=> throw new NotImplementedException();
+        public static Action<bool, GameObject> SetCameraPickupable { get; set; } = (x, y) => throw new NotImplementedException();
 
         private GameObject _photoCamera;
         private bool _pickupable;
-        private Camera _cachedCamera;
         private CameraSettings _cachedSettings;
 
-        private readonly float _cachedAperture = Settings.Camera.DefaultAperture;
-        private readonly float _cachedFocalDistance = Settings.Camera.DefaultFocalDistance;
-        private readonly float _cachedFocalLength = Settings.Camera.DefaultFocalLength;
-        private readonly Vector2 _cachedLensShift = Settings.Camera.DefaultLensShift;
-        private readonly Vector2 _cachedSensorSize = Settings.Camera.DefaultSensorSize;
-        private readonly Vector3 _cachedPosition;
-        private readonly Quaternion _cachedRotation;
+        private readonly float? _cachedAperture = null;
+        private readonly float? _cachedFocalDistance = null;
+        private readonly float? _cachedZoom = null;
+        private readonly Vector3? _cachedPosition = null;
+        private readonly Quaternion? _cachedRotation = null;
 
-        public StoreTransform()
+        public StoreTransform(GameObject photoCamera)
         {
+            Photocamera = photoCamera;
         }
 
-        public StoreTransform(float cachedAperture, float cachedFocalDistance, float cachedFocalLength, Vector2 cachedLensShift, Vector2 cachedSensorSize, Vector3 cachedPosition, Quaternion cachedRotation)
+        public StoreTransform(float cachedAperture, float cachedFocalDistance, float cachedZoom, Vector3 cachedPosition, Quaternion cachedRotation)
         {
             _cachedAperture = cachedAperture;
             _cachedFocalDistance = cachedFocalDistance;
-            _cachedFocalLength = cachedFocalLength;
-            _cachedLensShift = cachedLensShift;
-            _cachedSensorSize = cachedSensorSize;
+            _cachedZoom = cachedZoom;
             _cachedPosition = cachedPosition;
             _cachedRotation = cachedRotation;
         }
@@ -67,35 +62,58 @@ namespace CameraAnimation
         private void SetGameObject(GameObject value)
         {
             _photoCamera = value;
-            _cachedCamera = Photocamera.GetComponent<Camera>();
             _cachedSettings = Photocamera.GetComponent<CameraSettings>();
         }
 
         private float GetFocalDistance()
         {
             if (CameraAnimationMod.FocalDistanceProps.Count == 0 || _cachedSettings is null)
-                return _cachedFocalDistance;
+                return _cachedFocalDistance ?? Settings.Camera.DefaultFocalDistance;
 
-            return (float)(CameraAnimationMod.FocalDistanceProps[0]?.GetValue(_cachedSettings) ?? Settings.Camera.DefaultFocalDistance);
+            return CameraAnimationMod.FocalDistanceProps[0].GetValue(_cachedSettings).Unbox<float>();
         }
 
         private float GetAperture()
         {
             if (CameraAnimationMod.ApertureProps.Count == 0 || _cachedSettings is null)
-                return _cachedAperture;
+                return _cachedAperture ?? Settings.Camera.DefaultAperture;
 
-            return (float)(CameraAnimationMod.ApertureProps[0]?.GetValue(_cachedSettings) ?? Settings.Camera.DefaultAperture);
+            return CameraAnimationMod.ApertureProps[0].GetValue(_cachedSettings).Unbox<float>();
+        }
+
+        public float GetZoom()
+        {
+            if (CameraAnimationMod.ZoomProps.Count == 0 || _cachedSettings is null)
+                return _cachedZoom ?? Settings.Camera.DefaultAperture;
+
+            return CameraAnimationMod.ZoomProps[0].GetValue(_cachedSettings).Unbox<float>();
+
+        }
+
+        public Vector3 GetPosition()
+        {
+            if (_cachedPosition.HasValue)
+                return _cachedPosition.Value;
+
+            return Photocamera.transform.position;
+
+        }
+
+        public Vector4 GetRotation()
+        {
+            if (_cachedRotation.HasValue)
+                return _cachedRotation.Value.ToVector4();
+
+            return Photocamera.transform.localRotation.ToVector4();
         }
 
         public void Serialize(StringBuilder builder)
         {
             Position.Serialize(builder);
             Rotation.Serialize(builder);
-            FocalLength.Serialize(builder, ';');
-            LensShift.Serialize(builder);
-            SensorSize.Serialize(builder);
-            Aperture.Serialize(builder);
-            FocalDistance.Serialize(builder);
+            Zoom.Serialize(builder, ';');
+            Aperture.Serialize(builder, ';');
+            FocalDistance.Serialize(builder, ';');
             KeyPosition.Serialize(builder);
             KeyRotation.Serialize(builder);
             KeyZoom.Serialize(builder);

--- a/StoreTransform.cs
+++ b/StoreTransform.cs
@@ -8,67 +8,83 @@ namespace CameraAnimation
 {
     public class StoreTransform
     {
-        public GameObject Photocamera;
+        public GameObject Photocamera { get => _photoCamera; set => SetGameObject(value); }
+        
+        public Vector3 Position => Photocamera?.transform.position ?? _cachedPosition;
+        public Vector4 Rotation => Photocamera?.transform.localRotation.ToVector4() ?? _cachedRotation.ToVector4();
+        public float Aperture => GetAperture();
+        public float FocalDistance => GetFocalDistance();
 
-        public Vector3 Position => Photocamera.transform.position;
+        public float FocalLength => _cachedCamera?.focalLength ?? _cachedFocalLength;
+        public Vector2 LensShift => _cachedCamera?.lensShift ?? _cachedLensShift;
+        public Vector2 SensorSize => _cachedCamera?.sensorSize ?? _cachedSensorSize;
 
-        public Vector4 Rotation => new Vector4(Photocamera.transform.localRotation.x, Photocamera.transform.localRotation.y,
-                                                Photocamera.transform.localRotation.z, Photocamera.transform.localRotation.w);
-
-        public float FocalLength => _cachedCamera.focalLength;
-        public Vector2 LensShift => _cachedCamera.lensShift;
-
-        public Vector2 SensorSize => _cachedCamera.sensorSize;
-
-        public float Aperture
-        {
-            get
-            {
-                if(CameraAnimationMod.AperatureProps.Count==0)
-                    return 0;
-                return (float) CameraAnimationMod.AperatureProps[0].GetValue(_cachedSettings);
-            }
-        }
-        public float FocalDistance
-        {
-            get
-            {
-                if (CameraAnimationMod.FocalDistanceProps.Count == 0)
-                    return 0;
-                return (float)CameraAnimationMod.FocalDistanceProps[0].GetValue(_cachedSettings);
-            }
-        }
-
-        public bool KeyPosition { get; set; } = true;
-        public bool KeyRotation { get; set; } = true;
-        public bool KeyZoom { get; set; } = true;
-        public bool KeyFocus { get; set; } = true;
+        public bool KeyPosition { get; set; } = Settings.Keying.KeyPosition;
+        public bool KeyRotation { get; set; } = Settings.Keying.KeyRotation;
+        public bool KeyZoom { get; set; } = Settings.Keying.KeyZoom;
+        public bool KeyFocus { get; set; } = Settings.Keying.KeyFocus;
 
         public bool Pickupable
         {
-            get
-            {
-                return _pickupable;
-            }
+            get => _pickupable;
             set
             {
-                setCameraPickupable(value, Photocamera);
+                SetCameraPickupable(value, Photocamera);
                 _pickupable = value;
             }
         }
 
+        public static Action<bool, GameObject> SetCameraPickupable { get; set; } = (x,y)=> throw new NotImplementedException();
+
+        private GameObject _photoCamera;
         private bool _pickupable;
+        private Camera _cachedCamera;
+        private CameraSettings _cachedSettings;
 
-        private readonly Camera _cachedCamera;
-        private readonly CameraSettings _cachedSettings;
-        private readonly Action<bool, GameObject> setCameraPickupable;
+        private readonly float _cachedAperture = Settings.Camera.DefaultAperture;
+        private readonly float _cachedFocalDistance = Settings.Camera.DefaultFocalDistance;
+        private readonly float _cachedFocalLength = Settings.Camera.DefaultFocalLength;
+        private readonly Vector2 _cachedLensShift = Settings.Camera.DefaultLensShift;
+        private readonly Vector2 _cachedSensorSize = Settings.Camera.DefaultSensorSize;
+        private readonly Vector3 _cachedPosition;
+        private readonly Quaternion _cachedRotation;
 
-        public StoreTransform(GameObject camera, Action<bool, GameObject> setCameraPickupable)
+        public StoreTransform()
         {
-            Photocamera = camera;
+        }
+
+        public StoreTransform(float cachedAperture, float cachedFocalDistance, float cachedFocalLength, Vector2 cachedLensShift, Vector2 cachedSensorSize, Vector3 cachedPosition, Quaternion cachedRotation)
+        {
+            _cachedAperture = cachedAperture;
+            _cachedFocalDistance = cachedFocalDistance;
+            _cachedFocalLength = cachedFocalLength;
+            _cachedLensShift = cachedLensShift;
+            _cachedSensorSize = cachedSensorSize;
+            _cachedPosition = cachedPosition;
+            _cachedRotation = cachedRotation;
+        }
+
+        private void SetGameObject(GameObject value)
+        {
+            _photoCamera = value;
             _cachedCamera = Photocamera.GetComponent<Camera>();
             _cachedSettings = Photocamera.GetComponent<CameraSettings>();
-            this.setCameraPickupable = setCameraPickupable;
+        }
+
+        private float GetFocalDistance()
+        {
+            if (CameraAnimationMod.FocalDistanceProps.Count == 0 || _cachedSettings is null)
+                return _cachedFocalDistance;
+
+            return (float)(CameraAnimationMod.FocalDistanceProps[0]?.GetValue(_cachedSettings) ?? Settings.Camera.DefaultFocalDistance);
+        }
+
+        private float GetAperture()
+        {
+            if (CameraAnimationMod.ApertureProps.Count == 0 || _cachedSettings is null)
+                return _cachedAperture;
+
+            return (float)(CameraAnimationMod.ApertureProps[0]?.GetValue(_cachedSettings) ?? Settings.Camera.DefaultAperture);
         }
 
         public void Serialize(StringBuilder builder)

--- a/StoreTransform.cs
+++ b/StoreTransform.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text;
 using UnityEngine;
+using CameraSettings = MonoBehaviourPublicAcInCaInTeShInMaBoInUnique;
 
 namespace CameraAnimation
 {
@@ -11,7 +12,7 @@ namespace CameraAnimation
 
         public Vector3 Position => Photocamera.transform.position;
 
-        public Vector4 Rotation => new Vector4(Photocamera.transform.localRotation.x, Photocamera.transform.localRotation.y, 
+        public Vector4 Rotation => new Vector4(Photocamera.transform.localRotation.x, Photocamera.transform.localRotation.y,
                                                 Photocamera.transform.localRotation.z, Photocamera.transform.localRotation.w);
 
         public float FocalLength => _cachedCamera.focalLength;
@@ -19,29 +20,54 @@ namespace CameraAnimation
 
         public Vector2 SensorSize => _cachedCamera.sensorSize;
 
+        public float Aperture
+        {
+            get
+            {
+                if(CameraAnimationMod.AperatureProps.Count==0)
+                    return 0;
+                return (float) CameraAnimationMod.AperatureProps[0].GetValue(_cachedSettings);
+            }
+        }
+        public float FocalDistance
+        {
+            get
+            {
+                if (CameraAnimationMod.FocalDistanceProps.Count == 0)
+                    return 0;
+                return (float)CameraAnimationMod.FocalDistanceProps[0].GetValue(_cachedSettings);
+            }
+        }
+
         public bool KeyPosition { get; set; } = true;
         public bool KeyRotation { get; set; } = true;
         public bool KeyZoom { get; set; } = true;
+        public bool KeyFocus { get; set; } = true;
 
-        public bool Pickupable { 
-            get {
+        public bool Pickupable
+        {
+            get
+            {
                 return _pickupable;
-            } 
-            set {
+            }
+            set
+            {
                 setCameraPickupable(value, Photocamera);
                 _pickupable = value;
-            } 
+            }
         }
 
         private bool _pickupable;
 
         private readonly Camera _cachedCamera;
+        private readonly CameraSettings _cachedSettings;
         private readonly Action<bool, GameObject> setCameraPickupable;
 
         public StoreTransform(GameObject camera, Action<bool, GameObject> setCameraPickupable)
         {
             Photocamera = camera;
             _cachedCamera = Photocamera.GetComponent<Camera>();
+            _cachedSettings = Photocamera.GetComponent<CameraSettings>();
             this.setCameraPickupable = setCameraPickupable;
         }
 
@@ -52,9 +78,12 @@ namespace CameraAnimation
             FocalLength.Serialize(builder, ';');
             LensShift.Serialize(builder);
             SensorSize.Serialize(builder);
+            Aperture.Serialize(builder);
+            FocalDistance.Serialize(builder);
             KeyPosition.Serialize(builder);
             KeyRotation.Serialize(builder);
             KeyZoom.Serialize(builder);
+            KeyFocus.Serialize(builder);
         }
     }
 }

--- a/StoreTransform.cs
+++ b/StoreTransform.cs
@@ -21,12 +21,26 @@ namespace CameraAnimation
         public bool KeyRotation { get; set; } = true;
         public bool KeyZoom { get; set; } = true;
 
-        private readonly Camera _cachedCamera;
+        public bool Pickupable { 
+            get {
+                return _pickupable;
+            } 
+            set {
+                setCameraPickupable(value, Photocamera);
+                _pickupable = value;
+            } 
+        }
 
-        public StoreTransform(GameObject camera)
+        private bool _pickupable;
+
+        private readonly Camera _cachedCamera;
+        private readonly Action<bool, GameObject> setCameraPickupable;
+
+        public StoreTransform(GameObject camera, Action<bool, GameObject> setCameraPickupable)
         {
             Photocamera = camera;
             _cachedCamera = Photocamera.GetComponent<Camera>();
+            this.setCameraPickupable = setCameraPickupable;
         }
     }
 }

--- a/StoreTransform.cs
+++ b/StoreTransform.cs
@@ -92,19 +92,12 @@ namespace CameraAnimation
 
         public Vector3 GetPosition()
         {
-            if (_cachedPosition.HasValue)
-                return _cachedPosition.Value;
-
-            return Photocamera.transform.position;
-
+            return _cachedPosition ?? Photocamera.transform.position;
         }
 
         public Vector4 GetRotation()
         {
-            if (_cachedRotation.HasValue)
-                return _cachedRotation.Value.ToVector4();
-
-            return Photocamera.transform.localRotation.ToVector4();
+            return _cachedRotation?.ToVector4() ?? Photocamera.transform.localRotation.ToVector4();
         }
 
         public void Serialize(StringBuilder builder)

--- a/StoreTransform.cs
+++ b/StoreTransform.cs
@@ -11,8 +11,8 @@ namespace CameraAnimation
 
         public Vector3 Position => Photocamera.transform.position;
 
-        public Vector3 EulerAngles => Photocamera.transform.eulerAngles;
-        public Vector3 EulerAnglesCorrected;
+        public Vector4 Rotation => new Vector4(Photocamera.transform.localRotation.x, Photocamera.transform.localRotation.y, 
+                                                Photocamera.transform.localRotation.z, Photocamera.transform.localRotation.w);
 
         public float FocalLength => _cachedCamera.focalLength;
         public Vector2 LensShift => _cachedCamera.lensShift;
@@ -48,7 +48,7 @@ namespace CameraAnimation
         public void Serialize(StringBuilder builder)
         {
             Position.Serialize(builder);
-            EulerAngles.Serialize(builder);
+            Rotation.Serialize(builder);
             FocalLength.Serialize(builder, ';');
             LensShift.Serialize(builder);
             SensorSize.Serialize(builder);

--- a/TransformCurve.cs
+++ b/TransformCurve.cs
@@ -10,7 +10,7 @@ namespace CameraAnimation
     public class TransformCurve : ITransformCurve
     {
         public IVector3Curve Position { get; set; }
-        public IVector3Curve Rotation { get; set; }
+        public IVector4Curve Rotation { get; set; }
 
         public int Length => Math.Max( Position.Length, Rotation.Length );
 

--- a/TransformCurve.cs
+++ b/TransformCurve.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace CameraAnimation
+{
+    public class TransformCurve : ITransformCurve
+    {
+        public IVector3Curve Position { get; set; }
+        public IVector3Curve Rotation { get; set; }
+
+        public int Length => Math.Max( Position.Length, Rotation.Length );
+
+        public void Set(AnimationClip clip)
+        {
+            Position.Set(clip);
+            Rotation.Set(clip);
+        }
+    }
+}

--- a/VRCCamera.cs
+++ b/VRCCamera.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using VRC.UserCamera;
+using CameraSettings = MonoBehaviourPublicAcInCaInTeShInMaBoInUnique;
+
+namespace CameraAnimation
+{
+    public class VRCCamera : IVRCCamera
+    {
+        public GameObject PhotoCamera => GetPhotoCamera();
+        private GameObject _photoCamera;
+
+        public GameObject VideoCamera => GetVideoCamera();
+        private GameObject _videoCamera;
+
+        public CameraSettings Settings => GetSettings();
+        private CameraSettings _settings;
+
+        private GameObject GetPhotoCamera()
+        {
+            if (_photoCamera == null)
+            {
+                _photoCamera = RetrieveCamera("PhotoCamera");
+            }
+
+            // if unity would ever update it's damn c# version this could be reduced to ??= RetrieveCamera(); FFS...
+            return _photoCamera;
+        }
+
+        private GameObject GetVideoCamera()
+        {
+            if (_videoCamera == null)
+            {
+                _videoCamera = RetrieveCamera("VideoCamera");
+            }
+
+            // if unity would ever update it's damn c# version this could be reduced to ??= RetrieveCamera(); FFS...
+            return _videoCamera;
+        }
+
+        private CameraSettings GetSettings()
+        {
+            if (_settings != null) return _settings;
+            if (PhotoCamera == null) return null;
+            _settings = PhotoCamera.GetComponent<CameraSettings>();
+            return _settings;
+        }
+
+        private GameObject RetrieveCamera(string name)
+        {
+            UserCameraController controller = UserCameraController.field_Internal_Static_UserCameraController_0;
+
+            if (controller == null) return null;
+
+            foreach (var prop in typeof(UserCameraController).GetProperties().Where(x => x.Name.StartsWith("field_Public_GameObject_")))
+            {
+                var obj = prop.GetValue(controller) as GameObject;
+                if (obj != null && obj.name == name)
+                {
+                    return obj;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Vector3Curve.cs
+++ b/Vector3Curve.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace CameraAnimation
+{
+    public class Vector3Curve : Vector2Curve, IVector3Curve
+    {
+        public ICurve Z { get; set; }
+
+        public new int Length => Math.Max( X.Length, Math.Max( Y.Length, Z.Length ));
+
+        public (int, int, int) Add(float time, float x, float y, float z)
+        {
+            return (X.Add(time, x), Y.Add(time, y), Z.Add(time, z) );
+        }
+
+        public (int, int, int) Add(float time, Vector3 value)
+        {
+            return Add(time, value.x, value.y, value.z);
+        }
+
+        public new Vector3 Evaluate(float time)
+        {
+            return new Vector3( X.Evaluate(time), Y.Evaluate(time), Z.Evaluate(time) );
+        }
+
+        public new void Set(AnimationClip clip)
+        {
+            base.Set(clip);
+            Z.Set(clip);
+        }
+    }
+
+    public class Vector2Curve : IVector2Curve
+    {
+        public ICurve X { get; set; }
+        public ICurve Y { get; set; }
+
+        public int Length => Math.Max(X.Length,Y.Length);
+
+        public (int, int) Add(float time, float x, float y)
+        {
+            return (X.Add(time, x), Y.Add(time, y));
+        }
+
+        public (int, int) Add(float time, Vector2 value)
+        {
+            return Add(time, value.x, value.y);
+        }
+
+        public Vector2 Evaluate(float time)
+        {
+            return new Vector2(X.Evaluate(time), Y.Evaluate(time));
+        }
+
+        public void Set(AnimationClip clip)
+        {
+            X.Set(clip);
+            Y.Set(clip);
+        }
+    }
+}

--- a/VectorCurves.cs
+++ b/VectorCurves.cs
@@ -7,6 +7,34 @@ using UnityEngine;
 
 namespace CameraAnimation
 {
+    public class Vector4Curve : Vector3Curve, IVector4Curve
+    {
+        public ICurve W { get; set; }
+
+        public new int Length => Math.Max(X.Length, Math.Max(Math.Max(Y.Length, Z.Length), W.Length));
+
+        public (int, int, int, int) Add(float time, float x, float y, float z, float w)
+        {
+            return (X.Add(time, x), Y.Add(time, y), Z.Add(time, z), W.Add(time, w));
+        }
+
+        public (int, int, int, int) Add(float time, Vector4 value)
+        {
+            return Add(time, value.x, value.y, value.z, value.w);
+        }
+
+        public new Vector4 Evaluate(float time)
+        {
+            return new Vector4(X.Evaluate(time), Y.Evaluate(time), Z.Evaluate(time), W.Evaluate(time));
+        }
+
+        public new void Set(AnimationClip clip)
+        {
+            base.Set(clip);
+            W.Set(clip);
+        }
+    }
+
     public class Vector3Curve : Vector2Curve, IVector3Curve
     {
         public ICurve Z { get; set; }


### PR DESCRIPTION
- Added the ability to toggle on/off the "pickupable" status of all animation camera lenses
- Added the ability to toggle on/off position, rotation, zoom key frames
- Added zoom (Lens Shift, Sensor Size, and Focal Length) keying
- Refactored `StoredTransform` to allow for adding more keying
- Added serialization for added keying and modified existing keying
- Added ability to change key frame length (minimums and maximums) during runtime (this is separate from animation speed, which is unchanged)

Notes:
- No Icons were added to the added GUI features
- Zoom keying can be weird on very low end hardware (AKA integrated GPU). I've found when Zoom keying is enabled and VRC is running at 15-30FPS stuttering can occur in the animation. This cannot be replicated on higher hardware. This feature may want to be disabled by default until I/we can figure out why it's stuttering.